### PR TITLE
Let the OS pick a random port for us

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,3 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 structopt = "^0.2.15"
-rand = "^0.6.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use rand::{thread_rng, Rng};
 use std::{
     io,
     net::{SocketAddr, UdpSocket},
@@ -12,18 +11,14 @@ fn main() -> io::Result<()> {
     let opt = Cli::from_args();
 
     let address: SocketAddr = opt.remote.parse().expect("!! Unable to parse socket address");
-    let mut port = opt.port;
-
-    if opt.port == 0 {
-        let mut rng = thread_rng();
-        port = rng.gen_range(1024, 49151);
-    }
 
     let stdin = stdin_thread();
-    let socket = UdpSocket::bind(format!("0.0.0.0:{}", port))?;
+    let socket = UdpSocket::bind(format!("0.0.0.0:{}", opt.port))?;
     socket.set_nonblocking(true)?;
     let mut buf = [0; 255];
     socket.send_to("Client connected!\n".as_bytes(), address)?;
+
+    let port = socket.local_addr().expect("!! Unable to get local socket address").port();
 
     println!("Welcome to PunchChat!");
     println!("We are listening on port {}.", port);


### PR DESCRIPTION
Hello! 👋 I ran into this repo while looking around for hole punching stuff. I found a possible improvement. I don't know if this has been considered and rejected for some reason already or not. But I thought I would submit it and see if you like it.

By binding to port zero the OS will pick a random free port
to bind to for us. This has multiple advantages over picking a random
port ourselves:

1. We don't need to include a random number generator in our program.
2. We don't risk picking an already used port and fail the bind
   operation. The OS will make sure we get one that is free.